### PR TITLE
Update to handle auto-config via Answer file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-winserver-api",
       author="Nicholas Willhite,",
       author_email='willnx84@gmail.com',
-      version='2019.06.25',
+      version='2020.05.21',
       packages=find_packages(),
       include_package_data=True,
       package_files={'vlab_winserver_api' : ['app.ini']},

--- a/tests/test_vmware.py
+++ b/tests/test_vmware.py
@@ -111,13 +111,15 @@ class TestVMware(unittest.TestCase):
 
         self.assertEqual(output, expected)
 
+    @patch.object(vmware.time, 'sleep')
     @patch.object(vmware.virtual_machine, 'set_meta')
     @patch.object(vmware, 'Ova')
     @patch.object(vmware.virtual_machine, 'get_info')
     @patch.object(vmware.virtual_machine, 'deploy_from_ova')
     @patch.object(vmware, 'consume_task')
     @patch.object(vmware, 'vCenter')
-    def test_create_winserver_static_ip(self, fake_vCenter, fake_consume_task, fake_deploy_from_ova, fake_get_info, fake_Ova, fake_set_meta):
+    def test_create_winserver_static_ip(self, fake_vCenter, fake_consume_task,
+            fake_deploy_from_ova, fake_get_info, fake_Ova, fake_set_meta, fake_sleep):
         """``create_winserver`` sets a static IP when provided with one"""
         fake_logger = MagicMock()
         fake_deploy_from_ova.return_value.name = 'WinServerBox'

--- a/vlab_winserver_api/lib/worker/vmware.py
+++ b/vlab_winserver_api/lib/worker/vmware.py
@@ -108,6 +108,10 @@ def create_winserver(username, machine_name, image, network, ip_config, logger):
         finally:
             ova.close()
         if ip_config['static-ip']:
+            # Hack - The VM will walk through the C:\unattend.xml answer file
+            # and then reboot. We wont have valid login creds until after the
+            # reboot. Trying to *notice* the reboot is a race condition nightmare
+            time.sleep(300)
             virtual_machine.config_static_ip(vcenter,
                                              the_vm,
                                              ip_config['static-ip'],


### PR DESCRIPTION
This is needed in response to https://github.com/willnx/vlab/issues/74

The VM will boot without the Administrator password configured until after it's done processing the Answer file. 